### PR TITLE
Upgrade chamber, fix build for unvendoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # First stage: build the executable
 FROM golang:1 AS builder
 
-# Enable Go modules and vendor
-ENV GO111MODULE=on GOFLAGS=-mod=vendor
-
 # Set the Current Working Directory inside the container
 WORKDIR /app
 
@@ -16,7 +13,7 @@ COPY pkg pkg
 RUN CGO_ENABLED=0 GOOS=linux go build -o rotator .
 
 # Install chamber
-ENV CHAMBER_VERSION=v2.1.0
+ENV CHAMBER_VERSION=v2.8.2
 RUN wget -q https://github.com//segmentio/chamber/releases/download/${CHAMBER_VERSION}/chamber-${CHAMBER_VERSION}-linux-amd64 -O /bin/chamber
 RUN chmod +x /bin/chamber
 


### PR DESCRIPTION
Upgrades chamber to a version compatible with IRSA. Also removes build flags that forced there to be a vendor directory. Additionally recent version of Go no longer require an explicit flag to be set to force using Go modules, so removing the flag.