### PR TITLE
Fix goreleaser to copy needed files

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -20,5 +20,11 @@ dockers:
   - dockerfile: Dockerfile
     image_templates:
       - docker.pkg.github.com/chanzuckerberg/rotator/rotator:v{{.Version}}
+    extra_files:
+      - cmd
+      - go.mod
+      - go.sum
+      - main.go
+      - pkg
 env_files:
   github_token: ~/.config/goreleaser/github_token

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,6 @@ archives:
       - none*
 release:
   prerelease: false
-
 brews:
   - description: "Rotating credentials."
     github:
@@ -21,5 +20,11 @@ dockers:
   - dockerfile: Dockerfile
     image_templates:
       - docker.pkg.github.com/chanzuckerberg/rotator/rotator:v{{.Version}}
+    extra_files:
+      - cmd
+      - go.mod
+      - go.sum
+      - main.go
+      - pkg
 env_files:
   github_token: ~/.config/goreleaser/github_token


### PR DESCRIPTION
Goreleaser fails to build Docker containers because it needs to copy the context itself; it doesn't build the Dockerfile directly from the directory we run it in, so the Docker build errors out saying it cannot find a file.

This PR changes that by explicitly adding the list of files it needs to sent to the Docker daemon for the build.